### PR TITLE
allow DRF logger record 500 errors

### DIFF
--- a/drf_api_logger/middleware/api_logger_middleware.py
+++ b/drf_api_logger/middleware/api_logger_middleware.py
@@ -133,7 +133,7 @@ class APILoggerMiddleware:
                 return response
 
             if response.get('content-type') in (
-                    'application/json', 'application/vnd.api+json', 'application/gzip', 'application/octet-stream'):
+                    'application/json', 'application/vnd.api+json', 'application/gzip', 'application/octet-stream', 'text/html'):
 
                 if response.get('content-type') == 'application/gzip':
                     response_body = '** GZIP Archive **'
@@ -143,7 +143,10 @@ class APILoggerMiddleware:
                     response_body = '** Streaming **'
                 else:
                     if type(response.content) == bytes:
-                        response_body = json.loads(response.content.decode())
+                        try:
+                            response_body = json.loads(response.content.decode())
+                        except json.JSONDecodeError:
+                            response_body = response.content.decode()
                     else:
                         response_body = json.loads(response.content)
                 if self.DRF_API_LOGGER_PATH_TYPE == 'ABSOLUTE':

--- a/drf_api_logger/middleware/api_logger_middleware.py
+++ b/drf_api_logger/middleware/api_logger_middleware.py
@@ -73,6 +73,9 @@ class APILoggerMiddleware:
             mod = importlib.import_module(mod_name)
             self.tracing_func_name = getattr(mod, func_name)
 
+        self.DRF_API_LOG_SERVER_ERROR = getattr(settings, "DRF_API_LOG_SERVER_ERROR", False)
+        
+
     def process_exception(self, request, exception):
         # Set the stack trace for 500 erorrs
         self.stack_trace = traceback.format_exc()
@@ -135,6 +138,10 @@ class APILoggerMiddleware:
 
             # Log only registered methods if available.
             if len(self.DRF_API_LOGGER_METHODS) > 0 and method not in self.DRF_API_LOGGER_METHODS:
+                return response
+            
+            # This means do not log 500 errors
+            if response.get('content-type') == 'text/html' and not self.DRF_API_LOG_SERVER_ERROR:
                 return response
 
             if response.get('content-type') in (


### PR DESCRIPTION
Log 500 Error stack
<img width="1343" alt="Screen Shot 2024-01-30 at 7 17 09 PM" src="https://github.com/aspire-engineering/DRF-API-Logger/assets/54108285/9c895a5a-7308-4688-9697-34c639052c71">

<img width="1343" alt="Screen Shot 2024-01-30 at 7 17 25 PM" src="https://github.com/aspire-engineering/DRF-API-Logger/assets/54108285/b13d406b-159d-4546-b9ad-5c7e70724e92">

<img width="1343" alt="Screen Shot 2024-01-30 at 5 28 23 PM" src="https://github.com/aspire-engineering/DRF-API-Logger/assets/54108285/690caa71-aa30-417b-80e2-af54e16dd559">

Other error status code logging still works
<img width="1343" alt="Screen Shot 2024-01-30 at 7 20 05 PM" src="https://github.com/aspire-engineering/DRF-API-Logger/assets/54108285/851d401a-c0c1-4168-a605-0d8c4c5d0f99">

